### PR TITLE
Upgrade mypy version

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -18,7 +18,7 @@ pytest-env==0.6.2
 pylint==2.12.2
 
 # Mypy: check type usage in code
-mypy==0.931
+mypy==0.940
 
 # Sqlalchemy-stubs: type hints for sqlalchemy
 sqlalchemy2-stubs==0.0.2a20


### PR DESCRIPTION
This new mypy version was released 2 days ago

Now supports pattern matching, which was the only failing check we had so far. It does find a lot of new issues though, but they are actual _issues_ that the old mypy version should have detected as well (but didn't for some reason).