### PR TITLE
Add pylint rules back in

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -92,11 +92,13 @@ ignore_missing_imports = true
 
 [tool.pylint.master]
 load-plugins=["pylint_pytest"]
+argument-rgx = "[a-z_][a-z0-9_]{1,31}$"
 disable=[
     "import-outside-toplevel",
     "missing-module-docstring",
     "too-few-public-methods",
 ]
+extension-pkg-whitelist = "pydantic"
 
 [tool.pylint.format]
 max-line-length = 120


### PR DESCRIPTION
These two pylint rules were removed for some reason, not sure why. Either way I added them back in to get rid of a huge wall of false linter warnings.