### PR TITLE
Fix transaction commit

### DIFF
--- a/backend/src/app/logic/register.py
+++ b/backend/src/app/logic/register.py
@@ -13,16 +13,15 @@ def create_request(db: Session, new_user: NewUser, edition: Edition) -> None:
     """Create a coach request. If something fails, the changes aren't committed"""
     invite_link: InviteLink = get_invite_link_by_uuid(db, new_user.uuid)
 
-    with db.begin_nested() as transaction:
-        try:
-            # Make all functions in here not commit anymore,
-            # so we can roll back at the end if we have to
-            user = create_user(db, new_user.name, commit=False)
-            create_auth_email(db, user, get_password_hash(new_user.pw), new_user.email, commit=False)
-            create_coach_request(db, user, edition, commit=False)
-            delete_invite_link(db, invite_link, commit=False)
+    try:
+        # Make all functions in here not commit anymore,
+        # so we can roll back at the end if we have to
+        user = create_user(db, new_user.name, commit=False)
+        create_auth_email(db, user, get_password_hash(new_user.pw), new_user.email, commit=False)
+        create_coach_request(db, user, edition, commit=False)
+        delete_invite_link(db, invite_link, commit=False)
 
-            transaction.commit()
-        except sqlalchemy.exc.SQLAlchemyError as exception:
-            transaction.rollback()
-            raise FailedToAddNewUserException from exception
+        db.commit()
+    except sqlalchemy.exc.SQLAlchemyError as exception:
+        db.rollback()
+        raise FailedToAddNewUserException from exception


### PR DESCRIPTION
fixes #272 

Fixed a broken transaction commit.

As it turns out, when you don't have `AutoCommit` enabled, every `Session` is already a transaction by default, so we can just rollback without explicitly creating a savepoint. I _did_ have to create a savepoint in the tests, though, because they share the same connection and one rollbacked the other as a result.

This somehow did work in tests, God knows why.