### PR TITLE
Update footer links

### DIFF
--- a/frontend/src/components/Footer/FooterLinks.tsx
+++ b/frontend/src/components/Footer/FooterLinks.tsx
@@ -4,11 +4,22 @@ import { BASE_URL } from "../../settings";
 
 export default function FooterLinks() {
     return (
-        <Container fluid className={"px-4 pb-5"}>
+        <Container fluid className={"px-4 pb-4"}>
             <Row>
                 <Col>
-                    <h4>API</h4>
-                    <FooterLink href={`${BASE_URL}/redoc`}>Documentation</FooterLink>
+                    <h4>Documentation</h4>
+                    <FooterLink href={`${BASE_URL}/redoc`}>Backend API</FooterLink>
+                    <br />
+                    {/* This link is always production because we don't host the docs locally */}
+                    <FooterLink href={"https://sel2-3.ugent.be/docs"}>Frontend</FooterLink>
+                    <br />
+                    <FooterLink
+                        href={
+                            "https://github.com/SELab-2/OSOC-3/blob/develop/files/user_manual.pdf"
+                        }
+                    >
+                        User Manual
+                    </FooterLink>
                 </Col>
             </Row>
         </Container>

--- a/frontend/src/components/Footer/FooterLinks.tsx
+++ b/frontend/src/components/Footer/FooterLinks.tsx
@@ -11,7 +11,7 @@ export default function FooterLinks() {
                     <FooterLink href={`${BASE_URL}/redoc`}>Backend API</FooterLink>
                     <br />
                     {/* This link is always production because we don't host the docs locally */}
-                    <FooterLink href={"https://sel2-3.ugent.be/docs"}>Frontend</FooterLink>
+                    <FooterLink href={"https://sel2-3.ugent.be/typedoc/"}>Frontend</FooterLink>
                     <br />
                     <FooterLink
                         href={

--- a/frontend/src/components/Footer/styles.ts
+++ b/frontend/src/components/Footer/styles.ts
@@ -12,6 +12,7 @@ export const FooterTitle = styled.h3`
 export const FooterLink = styled.a`
     color: white;
     transition: 200ms ease-out;
+    text-decoration: none;
 
     &:hover {
         color: var(--osoc_green);


### PR DESCRIPTION
I've added a few more links to the footer, because we're now going to be hosting our frontend TypeDoc docs as well.

Fixes #309 

Footer now looks like this:
![image](https://user-images.githubusercontent.com/60451863/165586308-ca9999a3-0762-42ff-ae2f-cd9c3b75a8ca.png)
