### PR TITLE
Add students email link to navbar

### DIFF
--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -10,13 +10,14 @@ import UsersDropdown from "./UsersDropdown";
 import NavbarBase from "./NavbarBase";
 import { LinkContainer } from "react-router-bootstrap";
 import EditionNavLink from "./EditionNavLink";
+import StudentsDropdown from "./StudentsDropdown";
 
 /**
  * Navbar component displayed at the top of the screen.
  * If the user is not signed in, this is hidden automatically.
  */
 export default function Navbar() {
-    const { isLoggedIn, editions } = useAuth();
+    const { isLoggedIn, editions, role } = useAuth();
     /**
      * Important: DO NOT MOVE THIS LINE UNDERNEATH THE RETURN!
      * Placing an early return above a React hook (in this case, useLocation) causes
@@ -68,11 +69,9 @@ export default function Navbar() {
                         <LinkContainer to={`/editions/${currentEdition}/projects`}>
                             <Nav.Link>Projects</Nav.Link>
                         </LinkContainer>
-                        <LinkContainer to={`/editions/${currentEdition}/students`}>
-                            <Nav.Link>Students</Nav.Link>
-                        </LinkContainer>
                     </EditionNavLink>
-                    <UsersDropdown currentEdition={currentEdition} />
+                    <StudentsDropdown isLoggedIn={isLoggedIn} currentEdition={currentEdition} />
+                    <UsersDropdown currentEdition={currentEdition} role={role} />
                     <LogoutButton />
                 </Nav>
             </BSNavbar.Collapse>

--- a/frontend/src/components/Navbar/StudentsDropdown.tsx
+++ b/frontend/src/components/Navbar/StudentsDropdown.tsx
@@ -1,0 +1,27 @@
+import NavDropdown from "react-bootstrap/NavDropdown";
+import { LinkContainer } from "react-router-bootstrap";
+import { StyledDropdownItem } from "./styles";
+
+interface Props {
+    isLoggedIn: boolean;
+    currentEdition: string;
+}
+
+/**
+ * Dropdown in the [[Navbar]] that allows navigation to the [[StudentsPage]] and [[MailOverviewPage]].
+ * @constructor
+ */
+export default function StudentsDropdown(props: Props) {
+    if (!props.isLoggedIn) return null;
+
+    return (
+        <NavDropdown title={"Students"}>
+            <LinkContainer to={`/editions/${props.currentEdition}/students`}>
+                <StyledDropdownItem>Students</StyledDropdownItem>
+            </LinkContainer>
+            <LinkContainer to={`/editions/${props.currentEdition}/students/emails`}>
+                <StyledDropdownItem>Email History</StyledDropdownItem>
+            </LinkContainer>
+        </NavDropdown>
+    );
+}

--- a/frontend/src/components/Navbar/UsersDropdown.tsx
+++ b/frontend/src/components/Navbar/UsersDropdown.tsx
@@ -1,4 +1,3 @@
-import { useAuth } from "../../contexts";
 import NavDropdown from "react-bootstrap/NavDropdown";
 import { StyledDropdownItem } from "./styles";
 import { Role } from "../../data/enums";
@@ -7,15 +6,14 @@ import EditionNavLink from "./EditionNavLink";
 
 interface Props {
     currentEdition: string;
+    role: Role | null;
 }
 
 /**
  * NavDropdown that links to the [[AdminsPage]] and [[UsersPage]].
  * This component is only rendered for admins.
  */
-export default function UsersDropdown({ currentEdition }: Props) {
-    const { role } = useAuth();
-
+export default function UsersDropdown({ currentEdition, role }: Props) {
     // Only admins can see the dropdown because coaches can't
     // access these pages anyway
     if (role !== Role.ADMIN) {


### PR DESCRIPTION
Added a dropdown to allow navigation to the /students/emails page. Otherwise there was no way to even get here in the first place.