### PR TITLE
Change post & delete in removeAdminAndCoach

### DIFF
--- a/frontend/src/utils/api/users/admins.ts
+++ b/frontend/src/utils/api/users/admins.ts
@@ -38,7 +38,7 @@ export async function removeAdmin(userId: number) {
  * @param {number} userId The id of the user.
  */
 export async function removeAdminAndCoach(userId: number) {
-    const response1 = await axiosInstance.patch(`/users/${userId}`, { admin: false });
     const response2 = await axiosInstance.delete(`/users/${userId}/editions`);
+    const response1 = await axiosInstance.patch(`/users/${userId}`, { admin: false });
     return response1.status === 204 && response2.status === 204;
 }


### PR DESCRIPTION
fixes #319 

When the second request fails, the user will still be admin and you get a correct error message.
(Before: user was removed as admin but was still coach from some editions so you had remove him manually from every edition)