### PR TITLE
use create_all instead of migrations

### DIFF
--- a/backend/src/app/app.py
+++ b/backend/src/app/app.py
@@ -10,6 +10,7 @@ from src.database.exceptions import PendingMigrationsException
 from .exceptions import install_handlers
 from .routers import editions_router, login_router, skills_router
 from .routers.users.users import users_router
+from src.database.models import Base
 
 # Main application
 app = FastAPI(
@@ -41,9 +42,10 @@ async def startup():
     """
     Check if all migrations have been executed. If not refuse to start the app.
     """
-    alembic_config: config.Config = config.Config('alembic.ini')
-    alembic_script: script.ScriptDirectory = script.ScriptDirectory.from_config(alembic_config)
-    with engine.begin() as conn:
-        context: migration.MigrationContext = migration.MigrationContext.configure(conn)
-        if context.get_current_revision() != alembic_script.get_current_head():
-            raise PendingMigrationsException('Pending migrations')
+    # alembic_config: config.Config = config.Config('alembic.ini')
+    # alembic_script: script.ScriptDirectory = script.ScriptDirectory.from_config(alembic_config)
+    # with engine.begin() as conn:
+    #     context: migration.MigrationContext = migration.MigrationContext.configure(conn)
+    #     if context.get_current_revision() != alembic_script.get_current_head():
+    #         raise PendingMigrationsException('Pending migrations')
+    Base.metadata.create_all(bind=engine)

--- a/backend/src/app/app.py
+++ b/backend/src/app/app.py
@@ -1,16 +1,12 @@
-from alembic import config
-from alembic import script
-from alembic.runtime import migration
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
 import settings
 from src.database.engine import engine
-from src.database.exceptions import PendingMigrationsException
+from src.database.models import Base
 from .exceptions import install_handlers
 from .routers import editions_router, login_router, skills_router
 from .routers.users.users import users_router
-from src.database.models import Base
 
 # Main application
 app = FastAPI(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,32 +2,38 @@
 from typing import Generator
 
 import pytest
-from alembic import command
-from alembic import config
 from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
 
 from src.app import app
 from src.database.database import get_session
 from src.database.engine import engine
-
+from src.database.models import Base
 from tests.utils.authorization import AuthClient
+
+
+# @pytest.fixture(scope="session")
+# def tables():
+#     """
+#     Fixture to initialize a database before the tests,
+#     and drop it again afterwards
+#     """
+#     alembic_config: config.Config = config.Config('alembic.ini')
+#     command.upgrade(alembic_config, 'head')
+#     yield
+#     command.downgrade(alembic_config, 'base')
 
 
 @pytest.fixture(scope="session")
 def tables():
     """
-    Fixture to initialize a database before the tests,
-    and drop it again afterwards
+    Fixture to initialize a database before the tests
     """
-    alembic_config: config.Config = config.Config('alembic.ini')
-    command.upgrade(alembic_config, 'head')
-    yield
-    command.downgrade(alembic_config, 'base')
+    Base.metadata.create_all(bind=engine)
 
 
 @pytest.fixture
-def database_session(tables: None) -> Generator[Session, None, None]:
+def database_session(tables) -> Generator[Session, None, None]:
     """
     Fixture to create a session for every test, and rollback
     all the transactions so that each tests starts with a clean db


### PR DESCRIPTION
As discussed this pr moves away from using migrations in order to speed up the development for the final milestone.

We use the sqlalchemy `create_all` to create/modify the database schema for us. So concerning usability noting changed except you don't have to run the migrations anymore. As a drawback you might encounter more errors when switching branches, a database reset will solve this.

At the end of the milestone we can than re enable the migrations create a single migration file to solve the complex history