### PR TITLE
Add toasts for messages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.2.1",
         "react-scripts": "^5.0.0",
         "react-social-login-buttons": "^3.6.0",
+        "react-toastify": "^9.0.1",
         "reactjs-popup": "^2.0.5",
         "styled-components": "^5.3.3",
         "typescript": "^4.4.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "./App.css";
-import Router from "./Router";
+import "react-toastify/dist/ReactToastify.css";
 import { AuthProvider } from "./contexts";
+import { ToastContainer } from "react-toastify";
+import Router from "./Router";
 
 /**
  * Main application component. Wraps the [[Router]] in an [[AuthProvider]] so that
@@ -13,6 +15,7 @@ export default function App() {
         // AuthContext should be available in the entire application
         <AuthProvider>
             <Router />
+            <ToastContainer position={"bottom-right"} theme={"dark"} />
         </AuthProvider>
     );
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3198,6 +3198,11 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -7871,6 +7876,13 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
+
+react-toastify@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.0.1.tgz#2f3abd26a75efd55a82cb9c0a897c865218ea420"
+  integrity sha512-c2zeZHkCX+WXuItS/JRqQ/8CH8Qm/je+M0rt09xe9fnu5YPJigtNOdD8zX4fwLA093V2am3abkGfOowwpkrwOQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react-transition-group@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
I haven't replaced every alert & print & so on, that'd be a lot of work. Instead I just added the dependency & component required, so now we can each refactor a small page or something whenever we feel like it.

## Notes

### How to show a toast
Run `toast.success(message)`, `toast.info(message)`, `toast.warn(message)`, or `toast.error(message)`. That's it!

### Promises

We should use these for API calls!! This looks really clean!

It's very easy to do, see the example from the docs: https://fkhadra.github.io/react-toastify/promise

### Add id's to toasts

By passing a custom `id`, a toast doesn't show multiple times if the user spams a button. Docs: https://fkhadra.github.io/react-toastify/use-a-custom-id

```typescript
toast.info("This is a message", { toastId: "create-user" });
```

### You can call toasts from other TypeScript files

This allows you to show information/warnings **outside of React components** if you want to. Calling the `toast.X(message)`-functions is all it takes.