### PR TITLE
Fix navbar margin

### DIFF
--- a/frontend/src/components/Navbar/NavbarBase.tsx
+++ b/frontend/src/components/Navbar/NavbarBase.tsx
@@ -10,7 +10,7 @@ import Brand from "./Brand";
 export default function NavbarBase({ children }: { children?: React.ReactNode }) {
     return (
         <BSNavbar>
-            <Container>
+            <Container className={"mx-5"} fluid>
                 <Brand />
                 {children}
             </Container>


### PR DESCRIPTION
The margin in the navbar was very trippy, and pushed everything to the center when zooming out. I quickly added a bootstrap class that fixes this, and made the empty space on the sides a bit less.

Picture when zooming out as far as I can (notice how the buttons & icons are still nicely aligned to the right side instead of the center of the screen):
![image](https://user-images.githubusercontent.com/60451863/167915933-ac6e8623-b33c-4f26-87e6-a89e4bd8760b.png)
