### PR TITLE
Rewrite login page

### DIFF
--- a/frontend/src/components/Common/Buttons/styles.ts
+++ b/frontend/src/components/Common/Buttons/styles.ts
@@ -11,7 +11,9 @@ export const GreenButton = styled(Button)`
     border-color: var(--osoc_green);
     color: var(--osoc_blue);
 
-    &:hover {
+    &:hover,
+    &:active,
+    &:focus {
         background-color: var(--osoc_orange);
         border-color: var(--osoc_orange);
         color: var(--osoc_blue);

--- a/frontend/src/components/LoginComponents/WelcomeText/WelcomeText.tsx
+++ b/frontend/src/components/LoginComponents/WelcomeText/WelcomeText.tsx
@@ -6,12 +6,12 @@ import { WelcomeTextContainer } from "./styles";
 export default function WelcomeText() {
     return (
         <WelcomeTextContainer>
-            <h1 className={"mb-5"}>Hi!</h1>
-            <h3>
-                Welcome to the Open Summer of Code selections app. After you've logged in with your
-                account, we'll enable your account so you can get started. An admin will verify you
-                as soon as possible.
-            </h3>
+            <h1 className={"mb-5"}>Hi there!</h1>
+            <h3>Welcome to the Open Summer of Code selections app.</h3>
+            <h5>
+                After you've logged in with your account, we'll enable your account so you can get
+                started. An admin will verify you as soon as possible.
+            </h5>
         </WelcomeTextContainer>
     );
 }

--- a/frontend/src/utils/api/api.ts
+++ b/frontend/src/utils/api/api.ts
@@ -33,6 +33,13 @@ axiosInstance.interceptors.response.use(undefined, async (error: AxiosError) => 
             // If the token is already being refreshed, resend it (will be delayed until the token has been refreshed)
             return axiosInstance(error.config);
         } else {
+            // If the user is on the login page, don't try to refresh their token as
+            // they don't have one yet
+            // Instead just raise the error so we can show a message
+            if (window.location.pathname === "/") {
+                throw error;
+            }
+
             setRefreshTokenLock(true);
             try {
                 const tokens = await refreshTokens();
@@ -56,5 +63,6 @@ axiosInstance.interceptors.response.use(undefined, async (error: AxiosError) => 
             setRefreshTokenLock(false);
         }
     }
+
     throw error;
 });

--- a/frontend/src/utils/api/login.ts
+++ b/frontend/src/utils/api/login.ts
@@ -21,7 +21,7 @@ export async function logIn(
     auth: AuthContextState,
     email: string,
     password: string
-): Promise<boolean> {
+): Promise<number> {
     const payload = new FormData();
     payload.append("username", email);
     payload.append("password", password);
@@ -34,12 +34,11 @@ export async function logIn(
         setRefreshToken(login.refresh_token);
 
         ctxLogIn(login.user, auth);
-
-        return true;
+        return response.status;
     } catch (error) {
         if (axios.isAxiosError(error)) {
             auth.setIsLoggedIn(false);
-            return false;
+            return error.response?.status || 500;
         } else {
             auth.setIsLoggedIn(null);
             throw error;

--- a/frontend/src/views/LoginPage/LoginPage.tsx
+++ b/frontend/src/views/LoginPage/LoginPage.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { logIn } from "../../utils/api/login";
 
 import CreateButton from "../../components/Common/Buttons/CreateButton";
-import { Email, Password, SocialButtons, WelcomeText } from "../../components/LoginComponents";
+import { SocialButtons, WelcomeText } from "../../components/LoginComponents";
 
 import {
     EmailLoginContainer,
@@ -14,13 +14,25 @@ import {
     VerticalDivider,
 } from "./styles";
 import { useAuth } from "../../contexts";
+import { FormControl } from "../../components/Common/Forms";
+import FloatingLabel from "react-bootstrap/FloatingLabel";
+import Form from "react-bootstrap/Form";
+import { toast } from "react-toastify";
+
+export enum ToastId {
+    EmptyEmail = "login-empty-email",
+    EmptyPassword = "login-empty-password",
+    PendingRequest = "login-pending-request",
+}
 
 /**
  * Page where users can log in to the application.
  */
 export default function LoginPage() {
     const [email, setEmail] = useState("");
+    const [emailValid, setEmailValid] = useState(true);
     const [password, setPassword] = useState("");
+    const [passwordValid, setPasswordValid] = useState(true);
     const authCtx = useAuth();
     const navigate = useNavigate();
 
@@ -32,13 +44,44 @@ export default function LoginPage() {
         }
     }, [authCtx.isLoggedIn, navigate]);
 
+    async function handleSubmit(event: FormEvent) {
+        event.preventDefault();
+
+        // Show error messages & form validation when email or password are empty
+        if (!email) {
+            toast.error("Email address cannot be empty.", { toastId: ToastId.EmptyEmail });
+            setEmailValid(false);
+        }
+
+        if (!password) {
+            toast.error("Password cannot be empty.", { toastId: ToastId.EmptyPassword });
+            setPasswordValid(false);
+        }
+
+        if (email && password) {
+            toast.dismiss();
+            await toast.promise(
+                callLogIn,
+                {
+                    pending: "Logging in...",
+                },
+                { toastId: ToastId.PendingRequest }
+            );
+        }
+    }
+
     async function callLogIn() {
-        try {
-            const response = await logIn(authCtx, email, password);
-            if (response) navigate("/editions");
-            else alert("Something went wrong when login in");
-        } catch (error) {
-            console.log(error);
+        const status = await logIn(authCtx, email, password);
+        toast.dismiss();
+
+        if (status === 200) {
+            navigate("/editions");
+        } else if (status === 401) {
+            toast.error("Invalid email/password combination.");
+            setEmailValid(false);
+            setPasswordValid(false);
+        } else {
+            toast.warning("Something went wrong on our side.");
         }
     }
 
@@ -50,18 +93,46 @@ export default function LoginPage() {
                     <SocialButtons />
                     <VerticalDivider />
                     <EmailLoginContainer>
-                        <Email email={email} setEmail={setEmail} />
-                        <Password
-                            password={password}
-                            setPassword={setPassword}
-                            callLogIn={callLogIn}
-                        />
-                        <NoAccount>
-                            Don't have an account? Ask an admin for an invite link
-                        </NoAccount>
-                        <div>
-                            <CreateButton onClick={callLogIn} label={"Log In"} showIcon={false} />
-                        </div>
+                        <Form onSubmit={handleSubmit}>
+                            <FloatingLabel label={"Email address"} className={"mb-1"}>
+                                <FormControl
+                                    size={"lg"}
+                                    placeholder={"name@example.com"}
+                                    value={email}
+                                    onChange={e => {
+                                        setEmailValid(true);
+                                        setEmail(e.target.value);
+                                    }}
+                                    onFocus={() => setEmailValid(true)}
+                                    isInvalid={!emailValid}
+                                />
+                            </FloatingLabel>
+                            <FloatingLabel label={"Password"} className={"mb-3"}>
+                                <FormControl
+                                    size={"lg"}
+                                    type={"password"}
+                                    placeholder={"Password"}
+                                    value={password}
+                                    onChange={e => {
+                                        setPasswordValid(true);
+                                        setPassword(e.target.value);
+                                    }}
+                                    onFocus={() => setPasswordValid(true)}
+                                    isInvalid={!passwordValid}
+                                />
+                            </FloatingLabel>
+                            <NoAccount>
+                                Don't have an account? Ask an admin for an invite link
+                            </NoAccount>
+                            <div>
+                                <CreateButton
+                                    label={"Log In"}
+                                    showIcon={false}
+                                    type={"submit"}
+                                    className={"shadow-none"}
+                                />
+                            </div>
+                        </Form>
                     </EmailLoginContainer>
                 </LoginContainer>
             </LoginPageContainer>


### PR DESCRIPTION
I rewrote the login page to use some of our new components.

The page is not responsive because this was a really big struggle, mainly because of the GitHub button randomly giving itself some padding. I decided not to waste time on this anymore, as the site won't be used by mobile users anyways.

# ALSO

- Fancy form validation & toasts! Try sending logging in & sending some invalid requests (or leaving fields blank)!
- The name of the field now floats above the value you enter!
- Green outline when you select, bootstrap blue is ugly as hell

*Note: the API calls will return instantly because you're on localhost, in practice this will take a second or so.

*Also: the video below may look very purple for you, this is my screen recorder also capturing my laptop's night mode screen. I haven't done anything weird with the colourscheme :)

https://user-images.githubusercontent.com/60451863/168157655-6c876991-2368-4a53-b7da-4d161ad64aa3.mp4


