### PR TITLE
Problem with projects fixed

### DIFF
--- a/backend/src/database/models.py
+++ b/backend/src/database/models.py
@@ -174,8 +174,8 @@ class ProjectRole(Base):
     description = Column(Text, nullable=True)
     slots = Column(Integer, nullable=False, default=0)
 
-    project: Project = relationship("Project", back_populates="project_roles", uselist=False)
-    skill: Skill = relationship("Skill", back_populates="project_roles", uselist=False)
+    project: Project = relationship("Project", back_populates="project_roles", uselist=False, lazy="joined")
+    skill: Skill = relationship("Skill", back_populates="project_roles", uselist=False, lazy="joined")
     suggestions: list[ProjectRoleSuggestion] = relationship("ProjectRoleSuggestion", back_populates="project_role",
                                                             lazy="joined")
 


### PR DESCRIPTION
Even though the backend tests for this route pass, when the get_projects route was called form the frontend, the backend would give an error (similar to other errors that were fixed using lazy="joined"). These additions fix that error, and all projects can be requested by the frontend again