### PR TITLE
Only cover src

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -134,6 +134,9 @@ env = [
 concurrency = [
     "greenlet"
 ]
+include = [
+    "src/*"
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Oops, overlooked this in #410. Coverage report also includes the tests, which we don't want.