### PR TITLE
Catch 404 & 403's, patch in navbar

### DIFF
--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -42,6 +42,12 @@ export default function Navbar() {
     // Matched /editions/new path
     if (editionId === "new") {
         editionId = null;
+    } else if (editionId && !editions.includes(editionId)) {
+        // If the edition was not found in the user's list of editions,
+        // don't display it in the navbar!
+        // This will lead to a 404 or 403 re-route either way, so keep
+        // the previous/the best edition displayed in the dropdown
+        editionId = null;
     }
 
     // If the current URL contains an edition, use that

--- a/frontend/src/utils/api/api.ts
+++ b/frontend/src/utils/api/api.ts
@@ -62,6 +62,10 @@ axiosInstance.interceptors.response.use(undefined, async (error: AxiosError) => 
             }
             setRefreshTokenLock(false);
         }
+    } else if (error.response?.status === 403) {
+        window.location.replace("/403-forbidden");
+    } else if (error.response?.status === 404) {
+        window.location.replace("/404-not-found");
     }
 
     throw error;


### PR DESCRIPTION
- Catch all 404's and redirect them to /404
- Catch all 403's and redirect them to /403
- Small fix in the navbar: if an edition doesn't exist, don't display it in the dropdown but keep the current value. This avoids having a random edition in your navbar that you can't really get rid of.

It should be safe to catch all 404's and 403's because all requests that you send _on a page_ are either regular GET's that always exist, or filtered GET's that never throw a 404. This should only happen when you try to go to a page in your browser bar.

fixes #260 