### PR TITLE
Bugfix 204 requests

### DIFF
--- a/backend/src/app/routers/editions/editions.py
+++ b/backend/src/app/routers/editions/editions.py
@@ -1,5 +1,6 @@
 from asyncio import Queue
 
+from starlette.responses import Response
 from websockets.exceptions import ConnectionClosedOK
 from fastapi import APIRouter, Depends, WebSocket
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -69,7 +70,7 @@ async def post_edition(edition: EditionBase, db: AsyncSession = Depends(get_sess
 
 @editions_router.delete(
     "/{edition_name}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
     tags=[Tags.EDITIONS],
     dependencies=[Depends(require_admin)]
 )

--- a/backend/src/app/routers/editions/projects/projects.py
+++ b/backend/src/app/routers/editions/projects/projects.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
+from starlette.responses import Response
 
 import src.app.logic.projects as logic
 from src.app.routers.tags import Tags
@@ -56,7 +57,7 @@ async def get_conflicts(db: AsyncSession = Depends(get_session), edition: Editio
 
 @projects_router.delete(
     "/{project_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
     dependencies=[Depends(require_admin), Depends(live)]
 )
 async def delete_project(project: ProjectModel = Depends(get_project), db: AsyncSession = Depends(get_session)):
@@ -77,7 +78,7 @@ async def get_project_route(project: ProjectModel = Depends(get_project)):
 
 @projects_router.patch(
     "/{project_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
     dependencies=[Depends(require_admin), Depends(get_latest_edition), Depends(live)]
 )
 async def patch_project(
@@ -128,7 +129,7 @@ async def patch_project_role(
 
 @projects_router.delete(
     "/{project_id}/roles/{project_role_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
     dependencies=[Depends(require_admin), Depends(get_project), Depends(live)]
 )
 async def delete_project_role(

--- a/backend/src/app/routers/editions/projects/students/projects_students.py
+++ b/backend/src/app/routers/editions/projects/students/projects_students.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
+from starlette.responses import Response
 
 import src.app.logic.projects_students as logic
 from src.app.routers.tags import Tags
@@ -18,7 +19,7 @@ project_students_router = APIRouter(prefix="/students", tags=[Tags.PROJECTS, Tag
 
 @project_students_router.delete(
     "/{student_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
     dependencies=[Depends(require_coach), Depends(get_latest_edition), Depends(live)]
 )
 async def remove_student_from_project(
@@ -33,7 +34,7 @@ async def remove_student_from_project(
 
 @project_students_router.patch(
     "/{student_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
     dependencies=[Depends(get_latest_edition), Depends(live)]
 )
 async def change_project_role(

--- a/backend/src/app/routers/editions/students/students.py
+++ b/backend/src/app/routers/editions/students/students.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
+from starlette.responses import Response
 
 from src.app.logic.students import (
     definitive_decision_on_student, remove_student, get_student_return,
@@ -68,7 +69,7 @@ async def get_emails(
 @students_router.delete(
     "/{student_id}",
     dependencies=[Depends(require_admin), Depends(live)],
-    status_code=status.HTTP_204_NO_CONTENT
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
 )
 async def delete_student(student: Student = Depends(get_student), db: AsyncSession = Depends(get_session)):
     """
@@ -88,7 +89,7 @@ async def get_student_by_id(edition: Edition = Depends(get_edition), student: St
 @students_router.put(
     "/{student_id}/decision",
     dependencies=[Depends(require_admin), Depends(live)],
-    status_code=status.HTTP_204_NO_CONTENT
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
 )
 async def make_decision(
         decision: NewDecision,

--- a/backend/src/app/routers/editions/students/suggestions/suggestions.py
+++ b/backend/src/app/routers/editions/students/suggestions/suggestions.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from starlette import status
+from starlette.responses import Response
+
 from src.app.routers.tags import Tags
 from src.app.utils.dependencies import require_auth, get_student, get_suggestion
 from src.app.utils.websockets import live
@@ -35,7 +37,7 @@ async def create_suggestion(new_suggestion: NewSuggestion, student: Student = De
 
 @students_suggestions_router.delete(
     "/{suggestion_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
     dependencies=[Depends(live)]
 )
 async def delete_suggestion(db: AsyncSession = Depends(get_session), user: User = Depends(require_auth),
@@ -48,7 +50,7 @@ async def delete_suggestion(db: AsyncSession = Depends(get_session), user: User 
 
 @students_suggestions_router.put(
     "/{suggestion_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
+    status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
     dependencies=[Depends(get_student), Depends(live)]
 )
 async def edit_suggestion(new_suggestion: NewSuggestion, db: AsyncSession = Depends(get_session),

--- a/backend/src/app/routers/skills/skills.py
+++ b/backend/src/app/routers/skills/skills.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
+from starlette.responses import Response
 
 from src.app.logic import skills as logic_skills
 from src.app.routers.tags import Tags
@@ -24,8 +25,8 @@ async def create_skill(skill: SkillBase, db: AsyncSession = Depends(get_session)
     return await logic_skills.create_skill(db, skill)
 
 
-@skills_router.delete("/{skill_id}", status_code=status.HTTP_204_NO_CONTENT, tags=[Tags.SKILLS],
-                      dependencies=[Depends(require_auth)])
+@skills_router.delete("/{skill_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
+                      tags=[Tags.SKILLS], dependencies=[Depends(require_auth)])
 async def delete_skill(skill_id: int, db: AsyncSession = Depends(get_session)):
     """Delete an existing skill."""
     await logic_skills.delete_skill(db, skill_id)

--- a/backend/src/app/routers/users/users.py
+++ b/backend/src/app/routers/users/users.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Query, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
+from starlette.responses import Response
 
 import src.app.logic.users as logic
 from src.app.routers.tags import Tags
@@ -36,7 +37,8 @@ async def get_current_user(db: AsyncSession = Depends(get_session), user: UserDB
     return user_data
 
 
-@users_router.patch("/{user_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_admin)])
+@users_router.patch("/{user_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
+                    dependencies=[Depends(require_admin)])
 async def patch_admin_status(user_id: int, admin: AdminPatch, db: AsyncSession = Depends(get_session)):
     """
     Set admin-status of user
@@ -45,7 +47,7 @@ async def patch_admin_status(user_id: int, admin: AdminPatch, db: AsyncSession =
 
 
 @users_router.post("/{user_id}/editions/{edition_name}", status_code=status.HTTP_204_NO_CONTENT,
-                   dependencies=[Depends(require_admin)])
+                   response_class=Response, dependencies=[Depends(require_admin)])
 async def add_to_edition(user_id: int, edition_name: str, db: AsyncSession = Depends(get_session)):
     """
     Add user as coach of the given edition
@@ -54,7 +56,7 @@ async def add_to_edition(user_id: int, edition_name: str, db: AsyncSession = Dep
 
 
 @users_router.delete("/{user_id}/editions/{edition_name}", status_code=status.HTTP_204_NO_CONTENT,
-                     dependencies=[Depends(require_admin)])
+                     response_class=Response, dependencies=[Depends(require_admin)])
 async def remove_from_edition(user_id: int, edition_name: str, db: AsyncSession = Depends(get_session)):
     """
     Remove user as coach of the given edition
@@ -62,7 +64,7 @@ async def remove_from_edition(user_id: int, edition_name: str, db: AsyncSession 
     await logic.remove_coach(db, user_id, edition_name)
 
 
-@users_router.delete("/{user_id}/editions", status_code=status.HTTP_204_NO_CONTENT,
+@users_router.delete("/{user_id}/editions", status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
                      dependencies=[Depends(require_admin)])
 async def remove_from_all_editions(user_id: int, db: AsyncSession = Depends(get_session)):
     """
@@ -83,7 +85,7 @@ async def get_requests(
     return await logic.get_request_list(db, edition, user, page)
 
 
-@users_router.post("/requests/{request_id}/accept", status_code=status.HTTP_204_NO_CONTENT,
+@users_router.post("/requests/{request_id}/accept", status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
                    dependencies=[Depends(require_admin)])
 async def accept_request(request_id: int, db: AsyncSession = Depends(get_session)):
     """
@@ -92,7 +94,7 @@ async def accept_request(request_id: int, db: AsyncSession = Depends(get_session
     await logic.accept_request(db, request_id)
 
 
-@users_router.post("/requests/{request_id}/reject", status_code=status.HTTP_204_NO_CONTENT,
+@users_router.post("/requests/{request_id}/reject", status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
                    dependencies=[Depends(require_admin)])
 async def reject_request(request_id: int, db: AsyncSession = Depends(get_session)):
     """


### PR DESCRIPTION
Whenever a 204 request was sent, the backend would throw an error stating the content was longer then the specified content-length. This would not result in a crash, but was visible in the backend logs.

These changes fix this issue