### PR TITLE
Re-write readonly editions

### DIFF
--- a/backend/src/app/logic/editions.py
+++ b/backend/src/app/logic/editions.py
@@ -24,24 +24,16 @@ async def get_edition_by_name(db: AsyncSession, edition_name: str) -> EditionMod
 
 
 async def create_edition(db: AsyncSession, edition: EditionBase) -> EditionModel:
-    """ Create a new edition.
-
-    Args:
-        db (Session): connection with the database.
-
-    Returns:
-        Edition: the newly made edition object.
-    """
+    """Create a new edition."""
     return await crud_editions.create_edition(db, edition)
 
 
 async def delete_edition(db: AsyncSession, edition_name: str):
-    """Delete an existing edition.
-
-    Args:
-        db (Session): connection with the database.
-        edition_name (str): the name of the edition that needs to be deleted, if found.
-
-    Returns: nothing
-    """
+    """Delete an existing edition."""
     await crud_editions.delete_edition(db, edition_name)
+
+
+async def patch_edition(db: AsyncSession, edition: EditionModel, readonly: bool) -> EditionModel:
+    """Edit an existing edition"""
+    await crud_editions.patch_edition(db, edition, readonly)
+    return edition

--- a/backend/src/app/logic/users.py
+++ b/backend/src/app/logic/users.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import src.database.crud.users as users_crud
 from src.app.schemas.users import UsersListResponse, AdminPatch, UserRequestsResponse, user_model_to_schema, \
     FilterParameters, UserRequest
-from src.database.models import User
+from src.database.models import User, Edition
 
 
 async def get_users_list(
@@ -20,9 +20,9 @@ async def get_users_list(
     return UsersListResponse(users=[user_model_to_schema(user) for user in users_orm])
 
 
-async def get_user_editions(db: AsyncSession, user: User) -> list[str]:
+async def get_user_editions(db: AsyncSession, user: User) -> list[Edition]:
     """Get all names of the editions this user is coach in"""
-    return await users_crud.get_user_edition_names(db, user)
+    return await users_crud.get_user_editions(db, user)
 
 
 async def edit_admin_status(db: AsyncSession, user_id: int, admin: AdminPatch):

--- a/backend/src/app/routers/editions/editions.py
+++ b/backend/src/app/routers/editions/editions.py
@@ -10,7 +10,7 @@ from src.app.logic import editions as logic_editions
 from src.app.routers.tags import Tags
 from src.app.schemas.editions import EditionBase, Edition, EditionList, EditEdition
 from src.database.database import get_session
-from src.database.models import User
+from src.database.models import User, Edition as EditionDB
 from .invites import invites_router
 from .projects import projects_router
 from .register import registration_router
@@ -47,7 +47,7 @@ async def get_editions(db: AsyncSession = Depends(get_session), user: User = Dep
 
 @editions_router.patch("/{edition_name}", response_class=Response, tags=[Tags.EDITIONS],
                        dependencies=[Depends(require_admin)], status_code=status.HTTP_204_NO_CONTENT)
-async def patch_edition(edit_edition: EditEdition, edition: Edition = Depends(get_edition),
+async def patch_edition(edit_edition: EditEdition, edition: EditionDB = Depends(get_edition),
                         db: AsyncSession = Depends(get_session)):
     """Change the readonly status of an edition
     Note that this route is not behind "get_editable_edition", because otherwise you'd never be able

--- a/backend/src/app/routers/editions/editions.py
+++ b/backend/src/app/routers/editions/editions.py
@@ -16,7 +16,7 @@ from .projects import projects_router
 from .register import registration_router
 from .students import students_router
 from .webhooks import webhooks_router
-from ...utils.dependencies import require_admin, require_auth, require_coach, require_coach_ws, get_editable_edition
+from ...utils.dependencies import require_admin, require_auth, require_coach, require_coach_ws, get_edition
 from ...utils.websockets import DataPublisher, get_publisher
 
 # Don't add the "Editions" tag here, because then it gets applied
@@ -45,10 +45,15 @@ async def get_editions(db: AsyncSession = Depends(get_session), user: User = Dep
     return EditionList(editions=user.editions)
 
 
-@editions_router.patch("/{edition_name}", response_model=Edition, tags=[Tags.EDITIONS], dependencies=[Depends(require_admin)])
-async def patch_edition(edit_edition: EditEdition, edition: Edition = Depends(get_editable_edition), db: AsyncSession = Depends(get_session)):
-    """Change the readonly status of an edition"""
-    return await logic_editions.patch_edition(db, edition, edit_edition.readonly)
+@editions_router.patch("/{edition_name}", response_class=Response, tags=[Tags.EDITIONS],
+                       dependencies=[Depends(require_admin)], status_code=status.HTTP_204_NO_CONTENT)
+async def patch_edition(edit_edition: EditEdition, edition: Edition = Depends(get_edition),
+                        db: AsyncSession = Depends(get_session)):
+    """Change the readonly status of an edition
+    Note that this route is not behind "get_editable_edition", because otherwise you'd never be able
+    to change the status back to False
+    """
+    await logic_editions.patch_edition(db, edition, edit_edition.readonly)
 
 
 @editions_router.get(

--- a/backend/src/app/routers/editions/invites/invites.py
+++ b/backend/src/app/routers/editions/invites/invites.py
@@ -5,7 +5,7 @@ from starlette.responses import Response
 
 from src.app.logic.invites import create_mailto_link, delete_invite_link, get_pending_invites_page
 from src.app.routers.tags import Tags
-from src.app.utils.dependencies import get_edition, get_invite_link, require_admin, get_latest_edition
+from src.app.utils.dependencies import get_edition, get_invite_link, require_admin, get_editable_edition
 from src.app.schemas.invites import InvitesLinkList, EmailAddress, NewInviteLink, InviteLink as InviteLinkModel
 from src.database.database import get_session
 from src.database.models import Edition, InviteLink as InviteLinkDB
@@ -24,7 +24,7 @@ async def get_invites(db: AsyncSession = Depends(get_session), edition: Edition 
 @invites_router.post("", status_code=status.HTTP_201_CREATED, response_model=NewInviteLink,
                      dependencies=[Depends(require_admin)])
 async def create_invite(email: EmailAddress, db: AsyncSession = Depends(get_session),
-                        edition: Edition = Depends(get_latest_edition)):
+                        edition: Edition = Depends(get_editable_edition)):
     """
     Create a new invitation link for the current edition.
     """

--- a/backend/src/app/routers/editions/projects/projects.py
+++ b/backend/src/app/routers/editions/projects/projects.py
@@ -11,7 +11,7 @@ from src.app.schemas.projects import (
 from src.app.schemas.projects import (
     ProjectList, Project, InputProject, ConflictStudentList, QueryParamsProjects
 )
-from src.app.utils.dependencies import get_edition, get_project, require_admin, require_coach, get_latest_edition
+from src.app.utils.dependencies import get_edition, get_project, require_admin, require_coach, get_editable_edition
 from src.app.utils.websockets import live
 from src.database.database import get_session
 from src.database.models import Edition, Project as ProjectModel, User
@@ -40,7 +40,7 @@ async def get_projects(
 async def create_project(
         input_project: InputProject,
         db: AsyncSession = Depends(get_session),
-        edition: Edition = Depends(get_latest_edition)):
+        edition: Edition = Depends(get_editable_edition)):
     """Create a new project"""
     return await logic.create_project(db, edition,
                                       input_project)
@@ -79,7 +79,7 @@ async def get_project_route(project: ProjectModel = Depends(get_project)):
 @projects_router.patch(
     "/{project_id}",
     status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
-    dependencies=[Depends(require_admin), Depends(get_latest_edition), Depends(live)]
+    dependencies=[Depends(require_admin), Depends(get_editable_edition), Depends(live)]
 )
 async def patch_project(
         input_project: InputProject,
@@ -104,7 +104,7 @@ async def get_project_roles(project: ProjectModel = Depends(get_project), db: As
 @projects_router.post(
     "/{project_id}/roles",
     response_model=ProjectRoleSchema,
-    dependencies=[Depends(require_admin), Depends(get_latest_edition), Depends(live)]
+    dependencies=[Depends(require_admin), Depends(get_editable_edition), Depends(live)]
 )
 async def post_project_role(
         input_project_role: InputProjectRole,
@@ -117,7 +117,7 @@ async def post_project_role(
 @projects_router.patch(
     "/{project_id}/roles/{project_role_id}",
     response_model=ProjectRoleSchema,
-    dependencies=[Depends(require_admin), Depends(get_latest_edition), Depends(get_project), Depends(live)]
+    dependencies=[Depends(require_admin), Depends(get_editable_edition), Depends(get_project), Depends(live)]
 )
 async def patch_project_role(
         input_project_role: InputProjectRole,

--- a/backend/src/app/routers/editions/projects/students/projects_students.py
+++ b/backend/src/app/routers/editions/projects/students/projects_students.py
@@ -7,7 +7,7 @@ import src.app.logic.projects_students as logic
 from src.app.routers.tags import Tags
 from src.app.schemas.projects import InputArgumentation, ReturnProjectRoleSuggestion
 from src.app.utils.dependencies import (
-    require_coach, get_latest_edition, get_student,
+    require_coach, get_editable_edition, get_student,
     get_project_role, get_edition
 )
 from src.app.utils.websockets import live
@@ -35,7 +35,7 @@ async def remove_student_from_project(
 @project_students_router.patch(
     "/{student_id}",
     status_code=status.HTTP_204_NO_CONTENT, response_class=Response,
-    dependencies=[Depends(get_latest_edition), Depends(live)]
+    dependencies=[Depends(get_editable_edition), Depends(live)]
 )
 async def change_project_role(
         argumentation: InputArgumentation,
@@ -52,7 +52,7 @@ async def change_project_role(
 @project_students_router.post(
     "/{student_id}",
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(get_latest_edition), Depends(live)],
+    dependencies=[Depends(get_editable_edition), Depends(live)],
     response_model=ReturnProjectRoleSuggestion
 )
 async def add_student_to_project(

--- a/backend/src/app/routers/editions/register/register.py
+++ b/backend/src/app/routers/editions/register/register.py
@@ -7,7 +7,7 @@ from src.app.logic.oauth.github import get_github_access_token, get_github_profi
 from src.app.logic.register import create_request_email, create_request_github
 from src.app.routers.tags import Tags
 from src.app.schemas.register import EmailRegister, GitHubRegister
-from src.app.utils.dependencies import get_latest_edition, get_http_session
+from src.app.utils.dependencies import get_editable_edition, get_http_session
 from src.database.database import get_session
 from src.database.models import Edition
 
@@ -16,7 +16,7 @@ registration_router = APIRouter(prefix="/register", tags=[Tags.REGISTRATION])
 
 @registration_router.post("/email", status_code=status.HTTP_201_CREATED)
 async def register_email(register_data: EmailRegister, db: AsyncSession = Depends(get_session),
-                         edition: Edition = Depends(get_latest_edition)):
+                         edition: Edition = Depends(get_editable_edition)):
     """
     Register a new account using the email/password format.
     """
@@ -26,7 +26,7 @@ async def register_email(register_data: EmailRegister, db: AsyncSession = Depend
 @registration_router.post("/github", status_code=status.HTTP_201_CREATED)
 async def register_github(register_data: GitHubRegister, db: AsyncSession = Depends(get_session),
                           http_session: ClientSession = Depends(get_http_session),
-                          edition: Edition = Depends(get_latest_edition)):
+                          edition: Edition = Depends(get_editable_edition)):
     """Register a new account using GitHub OAuth."""
     access_token_data = await get_github_access_token(http_session, register_data.code)
     user_email = await get_github_profile(http_session, access_token_data.access_token)

--- a/backend/src/app/routers/editions/students/students.py
+++ b/backend/src/app/routers/editions/students/students.py
@@ -14,7 +14,7 @@ from src.app.schemas.students import (
     ReturnStudentMailList, NewEmail, EmailsSearchQueryParams,
     ListReturnStudentMailList
 )
-from src.app.utils.dependencies import get_latest_edition, get_student, get_edition, require_admin, require_auth
+from src.app.utils.dependencies import get_editable_edition, get_student, get_edition, require_admin, require_auth
 from src.app.utils.websockets import live
 from src.database.database import get_session
 from src.database.models import Student, Edition, User
@@ -47,7 +47,7 @@ async def get_students(db: AsyncSession = Depends(get_session),
 async def send_emails(
         new_email: NewEmail,
         db: AsyncSession = Depends(get_session),
-        edition: Edition = Depends(get_latest_edition)):
+        edition: Edition = Depends(get_editable_edition)):
     """
     Send a email to a list of students.
     """
@@ -92,7 +92,7 @@ async def get_student_by_id(edition: Edition = Depends(get_edition), student: St
 
 @students_router.put(
     "/{student_id}/decision",
-    dependencies=[Depends(require_admin), Depends(live), Depends(get_latest_edition)],
+    dependencies=[Depends(require_admin), Depends(live), Depends(get_editable_edition)],
     status_code=status.HTTP_204_NO_CONTENT
 )
 async def make_decision(

--- a/backend/src/app/routers/editions/students/suggestions/suggestions.py
+++ b/backend/src/app/routers/editions/students/suggestions/suggestions.py
@@ -5,7 +5,7 @@ from starlette import status
 from starlette.responses import Response
 
 from src.app.routers.tags import Tags
-from src.app.utils.dependencies import get_latest_edition, require_auth, get_student, get_suggestion
+from src.app.utils.dependencies import get_editable_edition, require_auth, get_student, get_suggestion
 from src.app.utils.websockets import live
 from src.database.database import get_session
 from src.database.models import Student, User, Suggestion
@@ -22,7 +22,7 @@ students_suggestions_router = APIRouter(
     "",
     status_code=status.HTTP_201_CREATED,
     response_model=SuggestionResponse,
-    dependencies=[Depends(live), Depends(get_latest_edition)]
+    dependencies=[Depends(live), Depends(get_editable_edition)]
 )
 async def create_suggestion(new_suggestion: NewSuggestion, student: Student = Depends(get_student),
                             db: AsyncSession = Depends(get_session), user: User = Depends(require_auth)):
@@ -51,7 +51,7 @@ async def delete_suggestion(db: AsyncSession = Depends(get_session), user: User 
 @students_suggestions_router.put(
     "/{suggestion_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(get_student), Depends(live), Depends(get_latest_edition)]
+    dependencies=[Depends(get_student), Depends(live), Depends(get_editable_edition)]
 )
 async def edit_suggestion(new_suggestion: NewSuggestion, db: AsyncSession = Depends(get_session),
                           user: User = Depends(require_auth), suggestion: Suggestion = Depends(get_suggestion)):

--- a/backend/src/app/routers/editions/webhooks/webhooks.py
+++ b/backend/src/app/routers/editions/webhooks/webhooks.py
@@ -5,7 +5,7 @@ from starlette import status
 from src.app.logic.webhooks import process_webhook
 from src.app.routers.tags import Tags
 from src.app.schemas.webhooks import WebhookEvent, WebhookUrlResponse
-from src.app.utils.dependencies import get_edition, require_admin, get_latest_edition
+from src.app.utils.dependencies import get_edition, require_admin, get_editable_edition
 from src.database.crud.webhooks import get_webhook, create_webhook
 from src.database.database import get_session
 from src.database.models import Edition
@@ -20,7 +20,7 @@ async def valid_uuid(uuid: str, database: AsyncSession = Depends(get_session)):
 
 @webhooks_router.post("", response_model=WebhookUrlResponse, status_code=status.HTTP_201_CREATED,
                       dependencies=[Depends(require_admin)])
-async def new(edition: Edition = Depends(get_latest_edition), database: AsyncSession = Depends(get_session)):
+async def new(edition: Edition = Depends(get_editable_edition), database: AsyncSession = Depends(get_session)):
     """Create a new webhook for an edition"""
     return await create_webhook(database, edition)
 

--- a/backend/src/app/routers/login/login.py
+++ b/backend/src/app/routers/login/login.py
@@ -9,6 +9,7 @@ from src.app.exceptions.authentication import InvalidCredentialsException
 from src.app.logic.security import authenticate_user_email, create_tokens, authenticate_user_github
 from src.app.logic.users import get_user_editions
 from src.app.routers.tags import Tags
+from src.app.schemas.editions import Edition
 from src.app.schemas.login import Token
 from src.app.schemas.users import user_model_to_schema
 from src.app.utils.dependencies import get_user_from_refresh_token, get_http_session
@@ -61,7 +62,8 @@ async def generate_token_response_for_user(db: AsyncSession, user: User) -> Toke
     access_token, refresh_token = create_tokens(user)
 
     user_data: dict = user_model_to_schema(user).__dict__
-    user_data["editions"] = await get_user_editions(db, user)
+    editions = await get_user_editions(db, user)
+    user_data["editions"] = list(map(Edition.from_orm, editions))
 
     return Token(
         access_token=access_token,

--- a/backend/src/app/routers/users/users.py
+++ b/backend/src/app/routers/users/users.py
@@ -5,6 +5,7 @@ from starlette.responses import Response
 
 import src.app.logic.users as logic
 from src.app.routers.tags import Tags
+from src.app.schemas.editions import Edition
 from src.app.schemas.login import UserData
 from src.app.schemas.users import UsersListResponse, AdminPatch, UserRequestsResponse, user_model_to_schema, \
     FilterParameters
@@ -32,8 +33,8 @@ async def get_users(
 async def get_current_user(db: AsyncSession = Depends(get_session), user: UserDB = Depends(get_user_from_access_token)):
     """Get a user based on their authorization credentials"""
     user_data = user_model_to_schema(user).__dict__
-    user_data["editions"] = await logic.get_user_editions(db, user)
-
+    editions = await logic.get_user_editions(db, user)
+    user_data["editions"] = list(map(Edition.from_orm, editions))
     return user_data
 
 

--- a/backend/src/app/schemas/editions.py
+++ b/backend/src/app/schemas/editions.py
@@ -22,6 +22,7 @@ class Edition(CamelCaseModel):
     edition_id: int
     name: str
     year: int
+    readonly: bool
 
     class Config:
         """Set to ORM mode"""
@@ -35,3 +36,10 @@ class EditionList(CamelCaseModel):
     class Config:
         """Set to ORM mode"""
         orm_mode = True
+
+
+class EditEdition(CamelCaseModel):
+    """Input schema to edit an edition
+    Only supported operation is patching the readonly status
+    """
+    readonly: bool

--- a/backend/src/app/schemas/login.py
+++ b/backend/src/app/schemas/login.py
@@ -1,10 +1,11 @@
+from src.app.schemas.editions import Edition
 from src.app.schemas.users import User
 from src.app.schemas.utils import BaseModel
 
 
 class UserData(User):
     """User information that can be passed to frontend"""
-    editions: list[str] = []
+    editions: list[Edition] = []
 
 
 class Token(BaseModel):

--- a/backend/src/app/utils/dependencies.py
+++ b/backend/src/app/utils/dependencies.py
@@ -18,7 +18,7 @@ from src.app.exceptions.authentication import (
 from src.app.exceptions.editions import ReadOnlyEditionException
 from src.app.exceptions.util import NotFound
 from src.app.logic.security import ALGORITHM, TokenType
-from src.database.crud.editions import get_edition_by_name, latest_edition
+from src.database.crud.editions import get_edition_by_name
 from src.database.crud.invites import get_invite_link_by_uuid
 from src.database.crud.students import get_student_by_id
 from src.database.crud.suggestions import get_suggestion_by_id
@@ -50,13 +50,12 @@ async def get_suggestion(suggestion_id: int, database: AsyncSession = Depends(ge
     return suggestion
 
 
-async def get_latest_edition(edition: Edition = Depends(get_edition), database: AsyncSession = Depends(get_session)) \
+async def get_editable_edition(edition: Edition = Depends(get_edition), database: AsyncSession = Depends(get_session)) \
         -> Edition:
-    """Checks if the given edition is the latest one (others are read-only) and returns it if it is"""
-    latest = await latest_edition(database)
-    if edition != latest:
+    """Checks if the requested edition is editable, and returns it if it is"""
+    if edition.readonly:
         raise ReadOnlyEditionException
-    return latest
+    return edition
 
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login/token/email")

--- a/backend/src/app/utils/dependencies.py
+++ b/backend/src/app/utils/dependencies.py
@@ -50,7 +50,7 @@ async def get_suggestion(suggestion_id: int, database: AsyncSession = Depends(ge
     return suggestion
 
 
-async def get_editable_edition(edition: Edition = Depends(get_edition), database: AsyncSession = Depends(get_session)) \
+async def get_editable_edition(edition: Edition = Depends(get_edition)) \
         -> Edition:
     """Checks if the requested edition is editable, and returns it if it is"""
     if edition.readonly:

--- a/backend/src/database/crud/editions.py
+++ b/backend/src/database/crud/editions.py
@@ -1,4 +1,4 @@
-from sqlalchemy import exc, func, select, desc
+from sqlalchemy import exc, select, desc
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import Select
 
@@ -70,12 +70,7 @@ async def delete_edition(db: AsyncSession, edition_name: str):
     await db.commit()
 
 
-async def latest_edition(db: AsyncSession) -> Edition:
-    """Returns the latest edition from the database"""
-    subquery = select(func.max(Edition.edition_id))
-    result = await db.execute(subquery)
-    max_edition_id = result.scalar()
-
-    query = select(Edition).where(Edition.edition_id == max_edition_id)
-    result2 = await db.execute(query)
-    return result2.scalars().one()
+async def patch_edition(db: AsyncSession, edition: Edition, readonly: bool):
+    """Update the readonly status of an edition"""
+    edition.readonly = readonly
+    await db.commit()

--- a/backend/src/database/crud/editions.py
+++ b/backend/src/database/crud/editions.py
@@ -24,7 +24,7 @@ async def get_edition_by_name(db: AsyncSession, edition_name: str) -> Edition:
 
 
 def _get_editions_query() -> Select:
-    return select(Edition).order_by(desc(Edition.edition_id))
+    return select(Edition).order_by(desc(Edition.year), desc(Edition.edition_id))
 
 
 async def get_editions(db: AsyncSession) -> list[Edition]:

--- a/backend/src/database/crud/users.py
+++ b/backend/src/database/crud/users.py
@@ -9,21 +9,10 @@ from src.database.crud.util import paginate
 from src.database.models import user_editions, User, Edition, CoachRequest, AuthEmail, AuthGitHub, AuthGoogle
 
 
-async def get_user_edition_names(db: AsyncSession, user: User) -> list[str]:
+async def get_user_editions(db: AsyncSession, user: User) -> list[Edition]:
     """Get all names of the editions this user can see"""
     # For admins: return all editions - otherwise, all editions this user is verified coach in
-    source = user.editions if not user.admin else await get_editions(db)
-
-    editions = []
-    # Name & year are non-nullable in the database, so it can never be None,
-    # but MyPy doesn't seem to grasp that concept just yet so we have to check it
-    # Could be a oneliner/list comp but that's a bit less readable
-    # Return from newest to oldest
-    for edition in sorted(source, key=lambda e: e.year or -1, reverse=True):
-        if edition.name is not None:
-            editions.append(edition.name)
-
-    return editions
+    return user.editions if not user.admin else await get_editions(db)
 
 
 async def get_users_filtered_page(db: AsyncSession, params: FilterParameters):

--- a/backend/src/database/crud/users.py
+++ b/backend/src/database/crud/users.py
@@ -12,18 +12,14 @@ from src.database.models import user_editions, User, Edition, CoachRequest, Auth
 async def get_user_editions(db: AsyncSession, user: User) -> list[Edition]:
     """Get all names of the editions this user can see"""
     # For admins: return all editions - otherwise, all editions this user is verified coach in
-    return user.editions if not user.admin else await get_editions(db)
+    # Sort by year first, id second, descending
+    return sorted(user.editions, key=lambda x: (x.year, x.edition_id), reverse=True) if not user.admin else await get_editions(
+        db)
 
 
 async def get_users_filtered_page(db: AsyncSession, params: FilterParameters):
     """
     Get users and filter by optional parameters:
-    :param admin: only return admins / only return non-admins
-    :param edition_name: only return users who are coach of the given edition
-    :param exclude_edition_name: only return users who are not coach of the given edition
-    :param name: a string which the user's name must contain
-    :param page: the page to return
-
     Note: When the admin parameter is set, edition_name and exclude_edition_name will be ignored.
     """
 

--- a/backend/src/database/crud/users.py
+++ b/backend/src/database/crud/users.py
@@ -13,8 +13,8 @@ async def get_user_editions(db: AsyncSession, user: User) -> list[Edition]:
     """Get all names of the editions this user can see"""
     # For admins: return all editions - otherwise, all editions this user is verified coach in
     # Sort by year first, id second, descending
-    return sorted(user.editions, key=lambda x: (x.year, x.edition_id), reverse=True) if not user.admin else await get_editions(
-        db)
+    return sorted(user.editions, key=lambda x: (x.year, x.edition_id),
+                  reverse=True) if not user.admin else await get_editions(db)
 
 
 async def get_users_filtered_page(db: AsyncSession, params: FilterParameters):
@@ -42,7 +42,7 @@ async def get_users_filtered_page(db: AsyncSession, params: FilterParameters):
 
     if params.exclude_edition is not None:
         exclude_edition = await get_edition_by_name(db, params.exclude_edition)
-        exclude_user_id = select(user_editions.c.user_id)\
+        exclude_user_id = select(user_editions.c.user_id) \
             .where(user_editions.c.edition_id == exclude_edition.edition_id)
 
         query = query.filter(User.user_id.not_in(exclude_user_id))
@@ -170,7 +170,7 @@ async def reject_request(db: AsyncSession, request_id: int):
 async def remove_request_if_exists(db: AsyncSession, user_id: int, edition_name: str):
     """Remove a pending request for a user if there is one, otherwise do nothing"""
     edition = (await db.execute(select(Edition).where(Edition.name == edition_name))).scalar_one()
-    delete_query = delete(CoachRequest).where(CoachRequest.user_id == user_id)\
+    delete_query = delete(CoachRequest).where(CoachRequest.user_id == user_id) \
         .where(CoachRequest.edition_id == edition.edition_id)
     await db.execute(delete_query)
     await db.commit()

--- a/backend/src/database/models.py
+++ b/backend/src/database/models.py
@@ -95,6 +95,7 @@ class Edition(Base):
     edition_id = Column(Integer, primary_key=True)
     name: str = Column(Text, unique=True, nullable=False)
     year: int = Column(Integer, nullable=False)
+    readonly: bool = Column(Boolean, nullable=False, default=False)
 
     invite_links: list[InviteLink] = relationship("InviteLink", back_populates="edition", cascade="all, delete-orphan")
     projects: list[Project] = relationship("Project", back_populates="edition", cascade="all, delete-orphan")

--- a/backend/tests/test_database/test_crud/test_users.py
+++ b/backend/tests/test_database/test_crud/test_users.py
@@ -200,9 +200,8 @@ async def test_get_user_editions_coach(database_session: AsyncSession):
     database_session.add(user)
     await database_session.commit()
 
-    # No editions yet
     editions = await users_crud.get_user_editions(database_session, user)
-    assert editions == [edition.name]
+    assert editions[0].name == edition.name
 
 
 async def test_get_all_users_from_edition(database_session: AsyncSession, data: dict[str, str]):

--- a/backend/tests/test_database/test_crud/test_users.py
+++ b/backend/tests/test_database/test_crud/test_users.py
@@ -149,7 +149,7 @@ async def test_get_all_admins_paginated_filter_name(database_session: AsyncSessi
             DB_PAGE_SIZE * 1.5), 0)
 
 
-async def test_get_user_edition_names_empty(database_session: AsyncSession):
+async def test_get_user_editions_empty(database_session: AsyncSession):
     """Test getting all editions from a user when there are none"""
     user = models.User(name="test")
     database_session.add(user)
@@ -158,11 +158,11 @@ async def test_get_user_edition_names_empty(database_session: AsyncSession):
     # query the user to initiate association tables
     await database_session.execute(select(models.User).where(models.User.user_id == user.user_id))
     # No editions yet
-    editions = await users_crud.get_user_edition_names(database_session, user)
+    editions = await users_crud.get_user_editions(database_session, user)
     assert len(editions) == 0
 
 
-async def test_get_user_edition_names_admin(database_session: AsyncSession):
+async def test_get_user_editions_admin(database_session: AsyncSession):
     """Test getting all editions for an admin"""
     user = models.User(name="test", admin=True)
     database_session.add(user)
@@ -175,11 +175,11 @@ async def test_get_user_edition_names_admin(database_session: AsyncSession):
     await database_session.execute(select(models.User).where(models.User.user_id == user.user_id))
 
     # Not added to edition yet, but admin can see it anyway
-    editions = await users_crud.get_user_edition_names(database_session, user)
+    editions = await users_crud.get_user_editions(database_session, user)
     assert len(editions) == 1
 
 
-async def test_get_user_edition_names_coach(database_session: AsyncSession):
+async def test_get_user_editions_coach(database_session: AsyncSession):
     """Test getting all editions for a coach when they aren't empty"""
     user = models.User(name="test")
     database_session.add(user)
@@ -192,7 +192,7 @@ async def test_get_user_edition_names_coach(database_session: AsyncSession):
     await database_session.execute(select(models.User).where(models.User.user_id == user.user_id))
 
     # No editions yet
-    editions = await users_crud.get_user_edition_names(database_session, user)
+    editions = await users_crud.get_user_editions(database_session, user)
     assert len(editions) == 0
 
     # Add user to a new edition
@@ -201,7 +201,7 @@ async def test_get_user_edition_names_coach(database_session: AsyncSession):
     await database_session.commit()
 
     # No editions yet
-    editions = await users_crud.get_user_edition_names(database_session, user)
+    editions = await users_crud.get_user_editions(database_session, user)
     assert editions == [edition.name]
 
 

--- a/backend/tests/test_routers/test_editions/test_editions/test_editions.py
+++ b/backend/tests/test_routers/test_editions/test_editions/test_editions.py
@@ -259,3 +259,18 @@ async def test_get_edition_by_name_coach_not_assigned(database_session: AsyncSes
         # Make the get request
         response = await auth_client.get(f"/editions/{edition2.name}")
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+async def test_patch_edition(database_session: AsyncSession, auth_client: AuthClient):
+    """Test changing the status of an edition"""
+    edition = Edition(year=2022, name="ed2022")
+    database_session.add(edition)
+    await database_session.commit()
+    await auth_client.admin()
+
+    async with auth_client:
+        response = await auth_client.patch(f"/editions/{edition.name}", json={"readonly": True})
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        response = await auth_client.get(f"/editions/{edition.name}")
+        assert response.json()["readonly"]

--- a/backend/tests/test_routers/test_editions/test_invites/test_invites.py
+++ b/backend/tests/test_routers/test_editions/test_invites/test_invites.py
@@ -182,10 +182,10 @@ async def test_get_invite_present(database_session: AsyncSession, auth_client: A
     assert json["email"] == "test@ema.il"
 
 
-async def test_create_invite_valid_old_edition(database_session: AsyncSession, auth_client: AuthClient):
+async def test_create_invite_valid_readonly_edition(database_session: AsyncSession, auth_client: AuthClient):
     """Test endpoint for creating invites when data is valid, but the edition is read-only"""
     await auth_client.admin()
-    edition = Edition(year=2022, name="ed2022")
+    edition = Edition(year=2022, name="ed2022", readonly=True)
     edition2 = Edition(year=2023, name="ed2023")
     database_session.add(edition)
     database_session.add(edition2)

--- a/backend/tests/test_routers/test_editions/test_projects/test_projects.py
+++ b/backend/tests/test_routers/test_editions/test_projects/test_projects.py
@@ -253,9 +253,9 @@ async def test_patch_wrong_project(database_session: AsyncSession, auth_client: 
         assert json['projects'][0]['name'] == project.name
 
 
-async def test_create_project_old_edition(database_session: AsyncSession, auth_client: AuthClient):
+async def test_create_project_readonly_edition(database_session: AsyncSession, auth_client: AuthClient):
     """test create a project for a readonly edition"""
-    edition_22: Edition = Edition(year=2022, name="ed2022")
+    edition_22: Edition = Edition(year=2022, name="ed2022", readonly=True)
     edition_23: Edition = Edition(year=2023, name="ed2023")
     database_session.add(edition_22)
     database_session.add(edition_23)

--- a/backend/tests/test_routers/test_editions/test_projects/test_students/test_students.py
+++ b/backend/tests/test_routers/test_editions/test_projects/test_students/test_students.py
@@ -97,9 +97,9 @@ async def test_add_pr_suggestion_non_existing_pr(database_session: AsyncSession,
         assert len((await database_session.execute(select(ProjectRoleSuggestion))).scalars().all()) == 0
 
 
-async def test_add_pr_suggestion_old_edition(database_session: AsyncSession, auth_client: AuthClient):
+async def test_add_pr_suggestion_readonly_edition(database_session: AsyncSession, auth_client: AuthClient):
     """tests add a student to a project from an old edition"""
-    edition: Edition = Edition(year=2022, name="ed2022")
+    edition: Edition = Edition(year=2022, name="ed2022", readonly=True)
     project: Project = Project(name="project 1", edition=edition)
     skill: Skill = Skill(name="skill 1")
     project_role: ProjectRole = ProjectRole(project=project, skill=skill, slots=1)

--- a/backend/tests/test_routers/test_editions/test_register/test_register.py
+++ b/backend/tests/test_routers/test_editions/test_register/test_register.py
@@ -101,9 +101,9 @@ async def test_duplicate_user(database_session: AsyncSession, test_client: Async
         assert response.status_code == status.HTTP_409_CONFLICT
 
 
-async def test_old_edition(database_session: AsyncSession, test_client: AsyncClient):
+async def test_readonly_edition(database_session: AsyncSession, test_client: AsyncClient):
     """Tests trying to make a registration for a read-only edition"""
-    edition: Edition = Edition(year=2022, name="ed2022")
+    edition: Edition = Edition(year=2022, name="ed2022", readonly=True)
     edition3: Edition = Edition(year=2023, name="ed2023")
     invite_link: InviteLink = InviteLink(
         edition=edition, target_email="jw@gmail.com")

--- a/backend/tests/test_routers/test_editions/test_students/test_students.py
+++ b/backend/tests/test_routers/test_editions/test_students/test_students.py
@@ -587,8 +587,11 @@ async def test_creat_email_for_ghost(database_with_data: AsyncSession, auth_clie
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-async def test_creat_email_student_in_other_edition(database_with_data: AsyncSession, auth_client: AuthClient):
-    """test creat an email for a student not in this edition"""
+async def test_create_email_student_in_other_edition_bulk(database_with_data: AsyncSession, auth_client: AuthClient):
+    """test creating an email for a student not in this edition when sending them in bulk
+    The expected result is that only the mails to students in that edition are sent, and the
+    others are ignored
+    """
     edition: Edition = Edition(year=2023, name="ed2023")
     database_with_data.add(edition)
     student: Student = Student(first_name="Mehmet", last_name="Dizdar", preferred_name="Mehmet",
@@ -599,7 +602,29 @@ async def test_creat_email_student_in_other_edition(database_with_data: AsyncSes
     await auth_client.admin()
     async with auth_client:
         response = await auth_client.post("/editions/ed2022/students/emails",
-                                          json={"students_id": [3], "email_status": 5})
+                                          json={"students_id": [1, student.student_id], "email_status": 5})
+
+        # When sending a request for students that aren't in this edition,
+        # it ignores them & creates emails for the rest instead
+        assert response.status_code == status.HTTP_201_CREATED
+        assert len(response.json()["studentEmails"]) == 1
+        assert response.json()["studentEmails"][0]["student"]["studentId"] == 1
+
+
+async def test_create_emails_readonly_edition(database_session: AsyncSession, auth_client: AuthClient):
+    """Test sending emails in a readonly edition"""
+    edition: Edition = Edition(year=2023, name="ed2023", readonly=True)
+    database_session.add(edition)
+    student: Student = Student(first_name="Mehmet", last_name="Dizdar", preferred_name="Mehmet",
+                               email_address="mehmet.dizdar@example.com", phone_number="(787)-938-6216", alumni=True,
+                               wants_to_be_student_coach=False, edition=edition, skills=[])
+    database_session.add(student)
+    await database_session.commit()
+    await auth_client.admin()
+
+    async with auth_client:
+        response = await auth_client.post(f"/editions/{edition.name}/students/emails",
+                                          json={"students_id": [student.student_id], "email_status": 5})
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 

--- a/backend/tests/test_routers/test_editions/test_webhooks/test_webhooks.py
+++ b/backend/tests/test_routers/test_editions/test_webhooks/test_webhooks.py
@@ -122,7 +122,8 @@ async def test_webhook_missing_question(test_client: AsyncClient, webhook: Webho
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-async def test_new_webhook_old_edition(database_session: AsyncSession, auth_client: AuthClient, edition: Edition):
+async def test_new_webhook_readonly_edition(database_session: AsyncSession, auth_client: AuthClient, edition: Edition):
+    edition.readonly = True
     database_session.add(Edition(year=2023, name="ed2023"))
     await database_session.commit()
     async with auth_client:

--- a/frontend/src/components/CurrentEditionRoute/CurrentEditionRoute.tsx
+++ b/frontend/src/components/CurrentEditionRoute/CurrentEditionRoute.tsx
@@ -1,16 +1,17 @@
 import { Navigate, Outlet, useParams } from "react-router-dom";
-import { useAuth } from "../../contexts/auth-context";
+import { useAuth } from "../../contexts";
 import { Role } from "../../data/enums";
+import { isReadonlyEdition } from "../../utils/logic";
 
 /**
- * React component for current edition and admin-only routes.
+ * React component for editable editions and admin-only routes.
  * Redirects to the [[LoginPage]] (status 401) if not authenticated,
- * and to the [[ForbiddenPage]] (status 403) if not admin or not the current edition.
+ * and to the [[ForbiddenPage]] (status 403) if not admin or read-only.
  *
  * Example usage:
  * ```ts
  * <Route path={"/path"} element={<CurrentEditionRoute />}>
- *     // These routes will only render if the user is an admin and is on the current edition
+ *     // These routes will only render if the user is an admin and is not on a read-only edition
  *     <Route path={"/"} />
  *     <Route path={"/child"} />
  * </Route>
@@ -22,7 +23,7 @@ export default function CurrentEditionRoute() {
     const editionId = params.editionId;
     return !isLoggedIn ? (
         <Navigate to={"/"} />
-    ) : role === Role.COACH || editionId !== editions[0] ? (
+    ) : role === Role.COACH || isReadonlyEdition(editionId, editions) ? (
         <Navigate to={"/403-forbidden"} />
     ) : (
         <Outlet />

--- a/frontend/src/components/EditionsPage/DeleteEditionButton.tsx
+++ b/frontend/src/components/EditionsPage/DeleteEditionButton.tsx
@@ -26,7 +26,7 @@ export default function DeleteEditionButton(props: Props) {
     }
 
     return (
-        <DeleteButton onClick={handleClick}>
+        <DeleteButton onClick={handleClick} className={"float-end"}>
             <FontAwesomeIcon icon={faTriangleExclamation as IconProp} /> Delete this edition
             <DeleteEditionModal edition={props.edition} show={showModal} setShow={setShowModal} />
         </DeleteButton>

--- a/frontend/src/components/EditionsPage/EditionRow.tsx
+++ b/frontend/src/components/EditionsPage/EditionRow.tsx
@@ -1,9 +1,13 @@
 import { Edition } from "../../data/interfaces";
 import DeleteEditionButton from "./DeleteEditionButton";
 import { RowContainer } from "./styles";
+import MarkReadonlyButton from "./MarkReadonlyButton";
+import React from "react";
+import Col from "react-bootstrap/Col";
 
 interface Props {
     edition: Edition;
+    handleClick: (edition: Edition) => Promise<void>;
 }
 
 /**
@@ -13,11 +17,21 @@ export default function EditionRow(props: Props) {
     return (
         <tr>
             <RowContainer>
-                <div className={"ms-0 me-auto"}>
-                    <h4>{props.edition.name}</h4>
-                    {props.edition.year}
-                </div>
-                <DeleteEditionButton edition={props.edition} />
+                <Col sm={"4"}>
+                    <div className={"ms-0"}>
+                        <h4>{props.edition.name}</h4>
+                        {props.edition.year}
+                    </div>
+                </Col>
+                <Col sm={"4"} className={"my-auto text-center"}>
+                    <MarkReadonlyButton
+                        edition={props.edition}
+                        handleClick={async () => await props.handleClick(props.edition)}
+                    />
+                </Col>
+                <Col sm={"4"} className={"my-auto"}>
+                    <DeleteEditionButton edition={props.edition} />
+                </Col>
             </RowContainer>
         </tr>
     );

--- a/frontend/src/components/EditionsPage/EditionsTable.tsx
+++ b/frontend/src/components/EditionsPage/EditionsTable.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { StyledTable, LoadingSpinner } from "./styles";
-import { getEditions } from "../../utils/api/editions";
+import { LoadingSpinner, StyledTable } from "./styles";
+import { getEditions, patchEdition } from "../../utils/api/editions";
 import EditionRow from "./EditionRow";
 import EmptyEditionsTableMessage from "./EmptyEditionsTableMessage";
+import { Edition } from "../../data/interfaces";
+import { toast } from "react-toastify";
+import { useAuth } from "../../contexts";
+import { Role } from "../../data/enums";
 
 /**
  * Table on the [[EditionsPage]] that renders a list of all editions
@@ -11,14 +15,29 @@ import EmptyEditionsTableMessage from "./EmptyEditionsTableMessage";
  * If the user is an admin, this will also render a delete button.
  */
 export default function EditionsTable() {
+    const { role } = useAuth();
     const [loading, setLoading] = useState(true);
     const [rows, setRows] = useState<React.ReactNode[]>([]);
+
+    async function handleClick(edition: Edition) {
+        if (role !== Role.ADMIN) return;
+
+        await toast.promise(async () => await patchEdition(edition.name, !edition.readonly), {
+            pending: "Changing edition status",
+            error: "Error changing status",
+            success: `Successfully changed status to ${
+                edition.readonly ? '"editable"' : '"read-only"'
+            }.`,
+        });
+
+        await loadEditions();
+    }
 
     async function loadEditions() {
         const response = await getEditions();
 
         const newRows: React.ReactNode[] = response.editions.map(edition => (
-            <EditionRow edition={edition} key={edition.name} />
+            <EditionRow edition={edition} key={edition.name} handleClick={handleClick} />
         ));
 
         setRows(newRows);
@@ -27,6 +46,7 @@ export default function EditionsTable() {
 
     useEffect(() => {
         loadEditions();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // Still loading: display a spinner instead

--- a/frontend/src/components/EditionsPage/EditionsTable.tsx
+++ b/frontend/src/components/EditionsPage/EditionsTable.tsx
@@ -5,7 +5,7 @@ import EditionRow from "./EditionRow";
 import EmptyEditionsTableMessage from "./EmptyEditionsTableMessage";
 import { Edition } from "../../data/interfaces";
 import { toast } from "react-toastify";
-import { useAuth } from "../../contexts";
+import { updateEditionState, useAuth } from "../../contexts";
 import { Role } from "../../data/enums";
 
 /**
@@ -15,21 +15,22 @@ import { Role } from "../../data/enums";
  * If the user is an admin, this will also render a delete button.
  */
 export default function EditionsTable() {
-    const { role } = useAuth();
+    const authCtx = useAuth();
     const [loading, setLoading] = useState(true);
     const [rows, setRows] = useState<React.ReactNode[]>([]);
 
     async function handleClick(edition: Edition) {
-        if (role !== Role.ADMIN) return;
+        if (authCtx.role !== Role.ADMIN) return;
 
         await toast.promise(async () => await patchEdition(edition.name, !edition.readonly), {
             pending: "Changing edition status",
             error: "Error changing status",
             success: `Successfully changed status to ${
-                edition.readonly ? '"editable"' : '"read-only"'
+                edition.readonly ? "editable" : "read-only"
             }.`,
         });
 
+        updateEditionState(authCtx, edition);
         await loadEditions();
     }
 

--- a/frontend/src/components/EditionsPage/MarkReadonlyButton.tsx
+++ b/frontend/src/components/EditionsPage/MarkReadonlyButton.tsx
@@ -1,0 +1,28 @@
+import { Edition } from "../../data/interfaces";
+import { StyledReadonlyText } from "./styles";
+import { useAuth } from "../../contexts";
+import { Role } from "../../data/enums";
+
+interface Props {
+    edition: Edition;
+    handleClick: () => void;
+}
+
+/**
+ * Button on the [[EditionsPage]], displayed in an [[EditionsRow]], to toggle the readonly
+ * state of an edition.
+ */
+export default function MarkReadonlyButton({ edition, handleClick }: Props) {
+    const { role } = useAuth();
+    const label = edition.readonly ? "READ-ONLY" : "EDITABLE";
+
+    return (
+        <StyledReadonlyText
+            readonly={edition.readonly}
+            onClick={handleClick}
+            clickable={role === Role.ADMIN}
+        >
+            {label}
+        </StyledReadonlyText>
+    );
+}

--- a/frontend/src/components/EditionsPage/styles.ts
+++ b/frontend/src/components/EditionsPage/styles.ts
@@ -37,3 +37,27 @@ export const StyledNewEditionButton = styled(Button).attrs(() => ({
         border-color: var(--osoc_orange);
     }
 `;
+
+interface TextProps {
+    readonly: boolean;
+    clickable: boolean;
+}
+
+export const StyledReadonlyText = styled.div<TextProps>`
+    text-decoration: none;
+    transition: 200ms ease-out;
+    color: ${props => (props.readonly ? "var(--osoc_red)" : "var(--osoc_green)")};
+    font-weight: bold;
+
+    // Only change style on hover for admins
+    ${({ clickable }) =>
+        clickable &&
+        `
+        &:hover {
+            text-decoration: underline;
+            transition: 200ms ease-out;
+            color: var(--osoc_orange);
+            cursor: pointer;
+        }
+        `};
+`;

--- a/frontend/src/components/Navbar/EditionDropdown.tsx
+++ b/frontend/src/components/Navbar/EditionDropdown.tsx
@@ -50,7 +50,7 @@ export default function EditionDropdown(props: Props) {
                 active={currentEdition === edition.name}
                 onClick={() => handleSelect(edition.name)}
             >
-                {edition}
+                {edition.name}
             </StyledDropdownItem>
         );
     });

--- a/frontend/src/components/Navbar/EditionDropdown.tsx
+++ b/frontend/src/components/Navbar/EditionDropdown.tsx
@@ -4,9 +4,10 @@ import { StyledDropdownItem } from "./styles";
 import { useLocation, useNavigate } from "react-router-dom";
 import { getCurrentEdition, setCurrentEdition } from "../../utils/session-storage";
 import { getBestRedirect } from "../../utils/logic";
+import { Edition } from "../../data/interfaces";
 
 interface Props {
-    editions: string[];
+    editions: Edition[];
 }
 
 /**
@@ -27,7 +28,7 @@ export default function EditionDropdown(props: Props) {
     // found in the list of editions
     // This shouldn't happen, but just in case
     // The list can never be empty because then we return null above ^
-    const currentEdition = getCurrentEdition() || props.editions[0];
+    const currentEdition = getCurrentEdition() || props.editions[0].name;
 
     /**
      * Change the route based on the edition
@@ -42,12 +43,12 @@ export default function EditionDropdown(props: Props) {
     }
 
     // Load dropdown items dynamically
-    props.editions.forEach((edition: string) => {
+    props.editions.forEach((edition: Edition) => {
         navItems.push(
             <StyledDropdownItem
-                key={edition}
-                active={currentEdition === edition}
-                onClick={() => handleSelect(edition)}
+                key={edition.name}
+                active={currentEdition === edition.name}
+                onClick={() => handleSelect(edition.name)}
             >
                 {edition}
             </StyledDropdownItem>

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -42,7 +42,7 @@ export default function Navbar() {
     // Matched /editions/new path
     if (editionId === "new") {
         editionId = null;
-    } else if (editionId && !editions.includes(editionId)) {
+    } else if (editionId && !editions.find(e => e.name === editionId)) {
         // If the edition was not found in the user's list of editions,
         // don't display it in the navbar!
         // This will lead to a 404 or 403 re-route either way, so keep
@@ -53,7 +53,7 @@ export default function Navbar() {
     // If the current URL contains an edition, use that
     // if not (eg. /editions), check SessionStorage
     // otherwise, use the most-recent edition from the auth response
-    const currentEdition = editionId || getCurrentEdition() || editions[0];
+    const currentEdition = editionId || getCurrentEdition() || editions[0].name;
 
     // Set the value of the new edition in SessionStorage if useful
     if (currentEdition) {

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -100,3 +100,18 @@ export function logOut(authContext: AuthContextState) {
     // Remove current edition from SessionStorage
     setCurrentEdition(null);
 }
+
+/**
+ * Update the state of an edition in the AuthContext
+ */
+export function updateEditionState(authContext: AuthContextState, edition: Edition) {
+    const index = authContext.editions.findIndex(e => e.name === edition.name);
+    if (index === -1) return;
+
+    // Flip the state of the element
+    const copy = [...authContext.editions];
+    copy[index].readonly = !copy[index].readonly;
+
+    // Call the setter to update the state
+    authContext.setEditions(copy);
+}

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -1,7 +1,7 @@
 /** Context hook to maintain the authentication state of the user **/
 import { Role } from "../data/enums";
 import React, { useContext, ReactNode, useState } from "react";
-import { User } from "../data/interfaces";
+import { Edition, User } from "../data/interfaces";
 import { setCurrentEdition } from "../utils/session-storage";
 import { setAccessToken, setRefreshToken } from "../utils/local-storage";
 
@@ -15,8 +15,8 @@ export interface AuthContextState {
     setRole: (value: Role | null) => void;
     userId: number | null;
     setUserId: (value: number | null) => void;
-    editions: string[];
-    setEditions: (value: string[]) => void;
+    editions: Edition[];
+    setEditions: (value: Edition[]) => void;
 }
 
 /**
@@ -33,7 +33,7 @@ function authDefaultState(): AuthContextState {
         userId: null,
         setUserId: (_: number | null) => {},
         editions: [],
-        setEditions: (_: string[]) => {},
+        setEditions: (_: Edition[]) => {},
     };
 }
 
@@ -56,7 +56,7 @@ export function useAuth(): AuthContextState {
 export function AuthProvider({ children }: { children: ReactNode }) {
     const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
     const [role, setRole] = useState<Role | null>(null);
-    const [editions, setEditions] = useState<string[]>([]);
+    const [editions, setEditions] = useState<Edition[]>([]);
     const [userId, setUserId] = useState<number | null>(null);
 
     // Create AuthContext value

--- a/frontend/src/contexts/index.ts
+++ b/frontend/src/contexts/index.ts
@@ -1,3 +1,3 @@
 import type { AuthContextState } from "./auth-context";
 export type { AuthContextState };
-export { AuthProvider, logIn, logOut, useAuth } from "./auth-context";
+export { AuthProvider, logIn, logOut, useAuth, updateEditionState } from "./auth-context";

--- a/frontend/src/data/interfaces/editions.ts
+++ b/frontend/src/data/interfaces/editions.ts
@@ -4,4 +4,5 @@
 export interface Edition {
     name: string;
     year: number;
+    readonly: boolean;
 }

--- a/frontend/src/data/interfaces/users.ts
+++ b/frontend/src/data/interfaces/users.ts
@@ -1,3 +1,5 @@
+import { Edition } from "./editions";
+
 /**
  * Data about a user using the application.
  * Contains a list of edition names so that we can quickly check if
@@ -7,5 +9,5 @@ export interface User {
     userId: number;
     name: string;
     admin: boolean;
-    editions: string[];
+    editions: Edition[];
 }

--- a/frontend/src/utils/api/editions.ts
+++ b/frontend/src/utils/api/editions.ts
@@ -15,9 +15,9 @@ export async function getEditions(): Promise<EditionsResponse> {
 }
 
 /**
- * Get all edition names sorted the user can see
+ * Get all edition names sorted that the user can see
  */
-export async function getSortedEditions(): Promise<string[]> {
+export async function getSortedEditions(): Promise<Edition[]> {
     const response = await axiosInstance.get("/users/current");
     return response.data.editions;
 }

--- a/frontend/src/utils/api/editions.ts
+++ b/frontend/src/utils/api/editions.ts
@@ -6,11 +6,6 @@ interface EditionsResponse {
     editions: Edition[];
 }
 
-interface EditionFields {
-    name: string;
-    year: number;
-}
-
 /**
  * Get all editions the user can see.
  */
@@ -39,7 +34,7 @@ export async function deleteEdition(name: string): Promise<number> {
  * Create a new edition with the given name and year
  */
 export async function createEdition(name: string, year: number): Promise<AxiosResponse> {
-    const payload: EditionFields = { name: name, year: year };
+    const payload = { name: name, year: year };
     try {
         return await axiosInstance.post("/editions", payload);
     } catch (error) {
@@ -49,4 +44,12 @@ export async function createEdition(name: string, year: number): Promise<AxiosRe
             throw error;
         }
     }
+}
+
+/**
+ * Change the readonly status of an edition
+ */
+export async function patchEdition(name: string, readonly: boolean): Promise<AxiosResponse> {
+    const payload = { readonly: readonly };
+    return await axiosInstance.patch(`/editions/${name}`, payload);
 }

--- a/frontend/src/utils/logic/editions.ts
+++ b/frontend/src/utils/logic/editions.ts
@@ -1,0 +1,9 @@
+import { Edition } from "../../data/interfaces";
+
+/**
+ * Check if an edition is read-only
+ */
+export function isReadonlyEdition(name: string | undefined, editions: Edition[]): boolean {
+    if (!name) return false;
+    return editions.find(e => e.name === name)?.readonly || false;
+}

--- a/frontend/src/utils/logic/index.ts
+++ b/frontend/src/utils/logic/index.ts
@@ -1,2 +1,3 @@
+export { isReadonlyEdition } from "./editions";
 export { createRedirectUri, decodeRegistrationLink } from "./registration";
 export { getBestRedirect } from "./routes";

--- a/frontend/src/views/projectViews/ProjectsPage/ProjectsPage.tsx
+++ b/frontend/src/views/projectViews/ProjectsPage/ProjectsPage.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../../../contexts";
 
 import { Role } from "../../../data/enums";
 import ConflictsButton from "../../../components/ProjectsComponents/Conflicts/ConflictsButton";
+import { isReadonlyEdition } from "../../../utils/logic";
 import { toast } from "react-toastify";
 /**
  * @returns The projects overview page where you can see all the projects.
@@ -137,7 +138,7 @@ export default function ProjectPage() {
                     placeholder="project name"
                 />
 
-                {role === Role.ADMIN && editionId === editions[0] && (
+                {role === Role.ADMIN && !isReadonlyEdition(editionId, editions) && (
                     <CreateButton
                         onClick={() => navigate("/editions/" + editionId + "/projects/new")}
                     >


### PR DESCRIPTION
- Made `read-only` a field of the edition instead of saying only the latest edition is editable
- Made a new route to change the status of an edition (admin-only)
- Sorted editions by year descending, and then by id
- Fix a few bugs in frontend
- Made an easy & reliable function to check if an edition is read-only or not (so we can hide components in frontend dynamically)
- Made an interactive label that displays the state of an edition on the `/editions` page. Can be clicked to toggle the state. This can _not_ be clicked by coaches, and is only visual to them. This label has no confirmation because it's a non-destructive action that can be undone in just 1 click.

## Note
I've had to re-write quite a bit of stuff to get this working, as lots of systems work together. It would be really cool if someone could quickly stress-test this a bit & double-check if everything still works. I've patched about 20 small edge cases myself, and I think I've got all of them now.