### PR TITLE
Fix states redirect

### DIFF
--- a/frontend/src/utils/logic/routes.test.ts
+++ b/frontend/src/utils/logic/routes.test.ts
@@ -5,6 +5,15 @@ import { getBestRedirect } from "./routes";
  * about the asterisk matching it
  */
 
+test("/students/states stays there", () => {
+    expect(getBestRedirect("/editions/old/students/states", "new")).toEqual(
+        "/editions/new/students/states"
+    );
+    expect(getBestRedirect("/editions/old/students/states/", "new")).toEqual(
+        "/editions/new/students/states"
+    );
+});
+
 test("/students stays there", () => {
     expect(getBestRedirect("/editions/old/students", "new")).toEqual("/editions/new/students");
     expect(getBestRedirect("/editions/old/students/", "new")).toEqual("/editions/new/students");

--- a/frontend/src/utils/logic/routes.ts
+++ b/frontend/src/utils/logic/routes.ts
@@ -5,7 +5,12 @@ import { matchPath } from "react-router-dom";
  * Boils down to the most-specific route that can be used across editions
  */
 export function getBestRedirect(location: string, editionName: string): string {
-    // All /student/X routes should go to /students
+    // Students/states should stay at /students/states
+    if (matchPath({ path: "/editions/:edition/students/states" }, location)) {
+        return `/editions/${editionName}/students/states`;
+    }
+
+    // All remaining /student/X routes should go to /students
     if (matchPath({ path: "/editions/:edition/students/*" }, location)) {
         return `/editions/${editionName}/students`;
     }


### PR DESCRIPTION
Changing the edition when on `/students/states` took you to `/students`, which shouldn't be happening.