### PR TITLE
fix bug when no editions yet

### DIFF
--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -53,7 +53,8 @@ export default function Navbar() {
     // If the current URL contains an edition, use that
     // if not (eg. /editions), check SessionStorage
     // otherwise, use the most-recent edition from the auth response
-    const currentEdition = editionId || getCurrentEdition() || editions[0].name;
+    const currentEdition =
+        editionId || getCurrentEdition() || (editions[0] && editions[0].name) || "";
 
     // Set the value of the new edition in SessionStorage if useful
     if (currentEdition) {

--- a/frontend/src/components/Navbar/StudentsDropdown.tsx
+++ b/frontend/src/components/Navbar/StudentsDropdown.tsx
@@ -15,7 +15,7 @@ interface Props {
  * @constructor
  */
 export default function StudentsDropdown(props: Props) {
-    if (!props.isLoggedIn) return null;
+    if (!props.isLoggedIn || !props.currentEdition) return null;
 
     if (props.role === Role.COACH) {
         return (


### PR DESCRIPTION
Frontend crashed when there were no editions, which isn't ideal.

Also, now hides the students dropdown, as you can't go anywhere anyways.